### PR TITLE
Install and configure eslint angular plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+{
+  "globals": {
+    "angular": false
+  },
+  "plugins": ["angular"],
+  "rules": {
+    "quotes": 0,
+    "no-shadow": 0,
+    "semi": 0,
+    "global-strict": 0,
+    "no-unused-vars": 0,
+    "no-multi-spaces": 0,
+    "consistent-return": 0,
+    "dot-notation": 0,
+    "curly": 0,
+    "no-undef": 0
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,21 @@
 var gulp = require('gulp'),
-    connect = require('gulp-connect');
+    connect = require('gulp-connect'),
+    eslint = require('gulp-eslint');
  
 gulp.task('webserver', function() {
 	connect.server({
 		root: 'app',
 		livereload: true
 	});
+});
+
+gulp.task('eslint', function() {
+    gulp
+        .src(['app/js/**/*.js'])
+        .pipe(eslint())
+        // .pipe(eslint.format())
+        .pipe(eslint.formatEach('stylish', process.stderr))
+    ;
 });
  
 gulp.task('default', ['webserver']);

--- a/package.json
+++ b/package.json
@@ -17,21 +17,20 @@
     "karma-jasmine": "^0.1.5",
     "protractor": "~1.0.0",
     "http-server": "^0.6.1",
-    "bower": "^1.3.1"
+    "bower": "^1.3.1",
+    "eslint": "~0.18.0",
+    "eslint-plugin-angular": "0.0.7",
+    "gulp-eslint": "~0.8.0"
   },
   "scripts": {
     "postinstall": "bower install",
-
     "prestart": "npm install",
     "start": "http-server -a 0.0.0.0 -p 8000",
-
     "pretest": "npm install",
     "test": "node node_modules/karma/bin/karma start test/karma.conf.js",
     "test-single-run": "node node_modules/karma/bin/karma start test/karma.conf.js  --single-run",
-
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",
-
     "preprotractor": "npm run update-webdriver",
     "protractor": "protractor test/protractor-conf.js"
   },


### PR DESCRIPTION
This PR fixes #8 by introducing and configuring `eslint-plugin-angular`. When refactoring has taken place to abide by the style guide, the `eslint` task should be added to the default gulp task.

*Caveat*: since the issue was angular-specific, all other default `eslint` rules were overridden via `"rulename": 0` in `.eslintrc`. Some of those rules are good, but contributors/maintainers should decide which rules to adopt.