### PR TITLE
Add will-change property to improve widget dragging/scrolling perf

### DIFF
--- a/app/css/vector.css
+++ b/app/css/vector.css
@@ -22,6 +22,7 @@
 
  .main-container {
    padding-top: 46px;
+   will-change: transform;
  }
 
  .spacer {
@@ -122,6 +123,10 @@
 
 .panel.widget {
    border: 1px solid #c4c4c4;
+}
+
+.widget-container {
+	will-change: transform;
 }
 
 .widget-header.panel-heading.ui-sortable-handle {


### PR DESCRIPTION
- Improves paint time when scrolling and dragging widgets around the
  page.
- Does not address issue with slow $digest cycle.

Before this changes here's how frame timeline looked like:

![before_transform](https://cloud.githubusercontent.com/assets/232300/7287402/d181fc8a-e919-11e4-9ae3-49058a682a21.png)

This cause some janking when dragging widgets around, and/or scrolling the page.

After adding 'will-change: transform' to some components, it enables the browser to paint in layers, some of the components, and improve paint performance.

The layers layout now looks as follows:
![layers_layout](https://cloud.githubusercontent.com/assets/232300/7287440/3b6007c8-e91a-11e4-9c9e-e7a9c5192380.png)

This shows that the navbar, widgets, and the container are painted separately, previously it was all in the same layer.

Here's the frame timeline after the change:
![after_transform](https://cloud.githubusercontent.com/assets/232300/7287422/0f0af746-e91a-11e4-8bcb-138430741350.png)

Now renders much faster than 16 ms, and overall improves the drag widget, and removes some of the janks.

