### PR TITLE
prototype for vector issue #2: separate pmwebd & pmcd connection config

### DIFF
--- a/src/app/css/vector.css
+++ b/src/app/css/vector.css
@@ -147,7 +147,12 @@
 }
 
 .form-control-feedback {
-    margin: 10px;
+    margin: 0px;
+    font-size: 16px;
+    line-height: 16px;
+    height: 16px;
+    position: static;
+    display: inline;
 }
 
 .widget-icon {

--- a/src/app/js/app.config.js
+++ b/src/app/js/app.config.js
@@ -21,7 +21,8 @@
     angular
         .module('vector.config')
         .constant('vectorConfig', {
-            'port': 44323,  // Port where pmwebd service listens
+            'host': 'localhost:44323',  // Port where pmwebd service listens
+            'pmcd': 'localhost',  // Hostspec for pmwebd to talk to pmcd
             'interval': 2,  // Default update interval in seconds
             'window': 2,    // Default graph time window in minutes
             'enableCpuFlameGraph': false,

--- a/src/app/js/dashboard.controller.js
+++ b/src/app/js/dashboard.controller.js
@@ -54,11 +54,25 @@
         function activate() {
             DashboardService.initializeProperties();
 
+            // XXX: overriding DashboardService::initializeProperties()
+
+            // pmwebd host
             if ($routeParams.host) {
-                $log.info("Host: " + $routeParams.host);
                 $rootScope.properties.host = $routeParams.host;
-                DashboardService.updateHost();
+            } else {
+                $rootScope.properties.host = window.location.host; // assuming pmwebd serving webapp
             }
+            // pmcd hostspec
+            if ($routeParams.pmcd) {
+                $rootScope.properties.pmcd = $routeParams.pmcd;
+            } else {
+                $rootScope.properties.pmcd = 'local:';
+            }
+
+            $log.info("PMWEBD Host: " + $rootScope.properties.host);
+            $log.info("PMCD Hostspec: " + $rootScope.properties.pmcd);
+
+            DashboardService.updateHost();
 
             // hack to deal with window/tab out of focus
             $document[0]

--- a/src/app/js/services/dashboard.service.js
+++ b/src/app/js/services/dashboard.service.js
@@ -89,6 +89,16 @@
             $rootScope.flags.contextAvailable = true;
             $rootScope.properties.context = data;
             updateInterval();
+            // fetch hostname
+            PMAPIService.getMetrics(data, ["pmcd.hostname"])
+                .then(function (metrics) {
+                    angular.forEach(metrics.values, function (values) {                    
+                        angular.forEach(values.instances, function (pair) {
+                            $rootScope.properties.hostname = metrics.values[0].instances[0].value;
+                            $log.info("Hostname updated: " + $rootScope.properties.hostname);
+                        });
+                    });
+                });
         }
 
         /**
@@ -107,13 +117,12 @@
         function updateContext() {
             $log.info("Context updated.");
 
-            var host = $rootScope.properties.host,
-                port = $rootScope.properties.port;
+            var host = $rootScope.properties.host;
 
             if (host && host !== '') {
                 $rootScope.flags.contextUpdating = true;
                 $rootScope.flags.contextAvailable = false;
-                PMAPIService.getHostspecContext('localhost', 600)
+                PMAPIService.getHostspecContext($rootScope.properties.pmcd, 600)
                     .then(function (data) {
                         $rootScope.flags.contextUpdating = false;
                         updateContextSuccessCallback(data);
@@ -133,6 +142,7 @@
             $log.info("Host updated.");
 
             $location.search('host', $rootScope.properties.host);
+            $location.search('pmcd', $rootScope.properties.pmcd);
 
             $rootScope.properties.context = -1;
 
@@ -163,10 +173,10 @@
                     $rootScope.properties.window = vectorConfig.window;
                 }
                 if (!$rootScope.properties.host) {
-                    $rootScope.properties.host = '';
+                    $rootScope.properties.host = vectorConfig.host;
                 }
-                if (!$rootScope.properties.port) {
-                    $rootScope.properties.port = vectorConfig.port;
+                if (!$rootScope.properties.pmcd) {
+                    $rootScope.properties.pmcd = vectorConfig.pmcd;
                 }
                 if (!$rootScope.properties.context ||
                     $rootScope.properties.context < 0) {

--- a/src/app/js/services/metriclist.service.js
+++ b/src/app/js/services/metriclist.service.js
@@ -189,7 +189,6 @@
             var metricArr = [],
                 url,
                 host = $rootScope.properties.host,
-                port = $rootScope.properties.port,
                 context = $rootScope.properties.context;
 
             if (context && context > 0 && simpleMetrics.length > 0) {
@@ -199,7 +198,7 @@
                 });
                 /*jslint unparam: false*/
 
-                url = 'http://' + host + ':' + port + '/pmapi/' + context + '/_fetch?names=' + metricArr.join(',');
+                url = 'http://' + host + '/pmapi/' + context + '/_fetch?names=' + metricArr.join(',');
 
                 PMAPIService.getMetrics(context, metricArr)
                     .then(function (metrics) {

--- a/src/app/js/services/pmapi.service.js
+++ b/src/app/js/services/pmapi.service.js
@@ -21,8 +21,7 @@
     function PMAPIService($http, $log, $rootScope, $q) {
 
         function getContext(params) {
-            var baseURI = 'http://' + $rootScope.properties.host + ':' +
-               $rootScope.properties.port;
+            var baseURI = 'http://' + $rootScope.properties.host;
             var settings = {};
             settings.method = 'GET';
             settings.url = baseURI + '/pmapi/context';
@@ -74,8 +73,7 @@
         }
 
         function getMetricsValues(context, names, pmids) {
-            var baseURI = 'http://' + $rootScope.properties.host + ':' +
-               $rootScope.properties.port;
+            var baseURI = 'http://' + $rootScope.properties.host;
             var settings = {};
             settings.method = 'GET';
             settings.url = baseURI + '/pmapi/' + context + '/_fetch';
@@ -103,8 +101,7 @@
         }
 
         function getInstanceDomainsByIndom(context, indom, instances, inames) {
-            var baseURI = 'http://' + $rootScope.properties.host + ':' +
-                $rootScope.properties.port;
+            var baseURI = 'http://' + $rootScope.properties.host;
             var settings = {};
             settings.method = 'GET';
             settings.url = baseURI + '/pmapi/' + context + '/_indom';
@@ -132,8 +129,7 @@
         }
 
         function getInstanceDomainsByName(context, name, instances, inames) {
-            var baseURI = 'http://' + $rootScope.properties.host + ':' +
-                $rootScope.properties.port;
+            var baseURI = 'http://' + $rootScope.properties.host;
             var settings = {};
             settings.method = 'GET';
             settings.url = baseURI + '/pmapi/' + context + '/_indom';

--- a/src/app/template/vector-dashboard.html
+++ b/src/app/template/vector-dashboard.html
@@ -2,10 +2,20 @@
     <div class="col-md-6">
         <form role="form" name="form">
             <div class="input-group input-group-lg" ng-class="{'has-error': form.host.$invalid && form.host.$dirty}">
-                <span class="input-group-addon">Hostname</span>
-                <input type="text" class="form-control" id="hostnameInput" name="host" data-content="Please enter a fully qualified instance hostname." rel="popover" data-placement="bottom" data-trigger="hover" data-container="body" ng-model="properties.host" ng-change="vm.updateHost()" ng-model-options="{ updateOn: 'default', debounce: 500 }" delay="1000" ng-disabled="flags.contextUpdating == true" required placeholder="Instance Hostname">
-                <i class="fa fa-refresh fa-2x form-control-feedback" ng-if="flags.contextUpdating"></i>
-                <i class="fa fa-check fa-2x form-control-feedback" ng-if="flags.contextAvailable"></i>
+              <accordion>
+                <accordion-group>
+                  <accordion-heading>
+                    <span class="input-group-lg">
+                      Hostname {{properties.context >= 0 ? properties.hostname : "(disconnected)"}}
+                      <i class="fa fa-refresh fa-2x form-control-feedback" ng-if="flags.contextUpdating"></i>
+                      <i class="fa fa-check fa-2x form-control-feedback" ng-if="flags.contextAvailable"></i>
+                    </span>
+                  </accordion-heading>
+                  <label>Please enter the pmwebd host:port and the pmcd hostspec.</label>
+                  <input type="text" class="form-control" id="hostnameInput" name="host" ng-model="properties.host" ng-change="vm.updateHost()" ng-model-options="{ updateOn: 'default', debounce: 500 }" ng-delay="500" required placeholder="PMWEBD" tooltip-placement="bottom" tooltip="Connection from vector to pmwebd: the web data relay">
+                  <input type="text" class="form-control" id="hostnameInput" name="pmcd" ng-model="properties.pmcd" ng-change="vm.updateHost()" ng-model-options="{ updateOn: 'default', debounce: 500 }" ng-delay="500" required placeholder="PMCD" tooltip-placement="bottom" tooltip="Connection from pmwebd to pmcd: the data source">
+                </accordion-group>
+              </accordion>
             </div>
         </form>
 


### PR DESCRIPTION
This prototype enables a deployment model for vector where a pmwebd
instance serves as a proxy/relay to get to pmcds running on actual
target machines.  This requires the simple host:port/hostname concept
to be split up into three:

a) $rootScope.properties.host     -- vector-to-pmwebd connectivity
b) $rootScope.properties.pmcd     -- pmwebd-to-pmcd connectivity
c) $rootScope.properties.hostname -- the pmcd.hostname from the target

The first two may be specified by a new "accordion" type gui from
angular/bootstrap, and default to the server whence the webapp is
served and local: respectively.  The latter is auto-computed during
context setup, and is the field shown on the normal live dashboard.