### PR TITLE
Typo on flame graph template location

### DIFF
--- a/src/app/charts/cpu-flame-graph.directive.js
+++ b/src/app/charts/cpu-flame-graph.directive.js
@@ -40,7 +40,7 @@
 
         return {
             restrict: 'A',
-            templateUrl: 'app/charts/pu-flame-graph.html',
+            templateUrl: 'app/charts/cpu-flame-graph.html',
             link: link
         };
     }


### PR DESCRIPTION
Btw, how exactly do you get a version of pmapi that answers to generic.systack ?