### PR TITLE
Memory Metric bug fix

### DIFF
--- a/src/app/components/datamodel/conversionMetric.datamodel.factory.js
+++ b/src/app/components/datamodel/conversionMetric.datamodel.factory.js
@@ -1,0 +1,60 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+ (function () {
+     'use strict';
+
+    /**
+    * @name SimpleMetricDataModel
+    * @desc
+    */
+    function ConversionMetricDataModel(WidgetDataModel, MetricListService, DashboardService) {
+        var DataModel = function () {
+            return this;
+        };
+
+        DataModel.prototype = Object.create(WidgetDataModel.prototype);
+
+        DataModel.prototype.init = function () {
+            WidgetDataModel.prototype.init.call(this);
+
+            this.name = this.dataModelOptions ? this.dataModelOptions.name : 'metric_' + DashboardService.getGuid();
+
+
+            var conversionFunction = function (value) {
+                    return value / 1024 / 1024;
+                };
+
+            this.metric = MetricListService.getOrCreateConvertedMetric(this.name, conversionFunction);
+
+            this.updateScope(this.metric.data);
+
+        };
+
+        DataModel.prototype.destroy = function () {
+            MetricListService.destroyMetric(this.name);
+
+            WidgetDataModel.prototype.destroy.call(this);
+        };
+
+        return DataModel;
+    }
+
+    angular
+        .module('datamodel')
+        .factory('ConversionMetricDataModel', ConversionMetricDataModel);
+ })();

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -25,6 +25,7 @@
     /* Widgets */
     function widgetDefinitions(
         MetricDataModel,
+        ConversionMetricDataModel,
         CumulativeMetricDataModel,
         CgroupCPUUsageMetricDataModel,
         CgroupCPUHeadroomMetricDataModel,
@@ -211,7 +212,7 @@
                 title: 'Memory Utilization (Free)',
                 directive: 'line-time-series',
                 dataAttrName: 'data',
-                dataModelType: MetricDataModel,
+                dataModelType: ConversionMetricDataModel,
                 dataModelOptions: {
                     name: 'mem.freemem'
                 },
@@ -226,7 +227,7 @@
                 title: 'Memory Utilization (Used)',
                 directive: 'line-time-series',
                 dataAttrName: 'data',
-                dataModelType: MetricDataModel,
+                dataModelType: ConversionMetricDataModel,
                 dataModelOptions: {
                     name: 'mem.util.used'
                 },
@@ -241,7 +242,7 @@
                 title: 'Memory Utilization (Cached)',
                 directive: 'line-time-series',
                 dataAttrName: 'data',
-                dataModelType: MetricDataModel,
+                dataModelType: ConversionMetricDataModel,
                 dataModelOptions: {
                     name: 'mem.util.cached'
                 },


### PR DESCRIPTION
I found some bug

Clear all Widgets => Show Memory Util(total) => Show Memory Util(used, free, cache...)  it's ok

but

Clear all Widgets => Show Memory Util(used, free, cache...)   => Show Memory Util(total) it's wrong 

because they share simple metrics, one used it as conversion metric but another not.

I think it need to be fixed!

thank you