### PR TITLE
Optimized Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
+# Copyright 2016 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:latest
-MAINTAINER Jan Garaj info@monitoringartist.com
+MAINTAINER Martin Spier <mspier@netflix.com>
 
 # version = git branch/tag, e.g. master, stable, tags/1.1.0, ...
 ENV VECTOR_VERSION=tags/v1.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,33 @@
-# Copyright 2016 Netflix, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+FROM alpine:latest
+MAINTAINER Jan Garaj info@monitoringartist.com
 
-FROM httpd:2.4
-MAINTAINER Martin Spier <mspier@netflix.com>
+# version = git branch/tag, e.g. master, stable, tags/1.1.0, ...
+ENV VECTOR_VERSION=tags/v1.1.0
 
-COPY /dist /usr/local/apache2/htdocs
-
+RUN apk add --update git nodejs curl && \
+    cd /tmp && \
+    git clone https://github.com/Netflix/vector.git && \
+    cd vector && \
+    git checkout ${VECTOR_VERSION} && \
+    npm install && \
+    npm install -g gulp bower && \
+    bower install --allow-root && \
+    gulp build && \
+    mkdir -p /usr/share/nginx/html && \
+    mv dist/* /usr/share/nginx/html && \
+    cd / && \
+    curl --silent --show-error --fail --location \
+      --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
+      "https://caddyserver.com/download/build?os=linux&arch=amd64" \
+      | tar --no-same-owner -C /usr/bin/ -xz caddy && \
+    chmod 0755 /usr/bin/caddy && \
+    /usr/bin/caddy -version && \
+    npm uninstall -g gulp bower && \
+    apk del git nodejs curl && \    
+    rm -rf /root/.npm /root/.cache /root/.config /root/.local /root/.ash_history \
+      /root/.v8flags* /usr/share/man /tmp/* /var/cache/apk/* \
+      /usr/local/{lib/node{,/.npm,_modules},bin,share/man}/npm*
+          
 EXPOSE 80
+CMD ["/usr/bin/caddy", "-root", "/usr/share/nginx/html", "-port", "80"]
+VOLUME ["/usr/share/nginx/html"]    


### PR DESCRIPTION
Official Docker image `netflixoss/vector` is still missing - #15

Changes:
- optimization for size: image from [original Dockerfile](https://github.com/Netflix/vector/blob/d33fd9bc080bcf99a2dcdee1955f128d8228919f/Dockerfile) -> 241.3 MB,
 Image from this new Dockerfile -> 29.85 MB
- base image is alpine; standard Docker images (CentOS, Debian, Ubuntu) have still security issues (see their security scans in Docker Hub)
- image has Caddy webserver (Let's encrypt support), it can be used as a storage volume for standard nginx Docker image)
- env version variable - easy creation of Dockerfile per tag
- no dependency on build artifacts from bintray (better for automated builds)


Please create automated build and sync repo tags with image tags (e.g. `:v1.1.0`,...), stable = `:latest` + branch master can be `:dev` image tag

Please update also doc https://github.com/Netflix/vector/wiki/Getting-Started:

With [Caddy webserver](https://github.com/mholt/caddy) (recommended):
```
docker run \
  -d \
  --name vector \
  -p 80:80 \
  netflixoss/vector:latest
```

With nginx (vector Docker image is only used as a volume only):

```
# start vector-storage
docker run  \
  -d \
  --name vector-storage \
  netflixoss/vector:latest true
# start vector-nginx
docker run \
  -d \
  --name vector-nginx \
  --volumes-from vector-storage \
  -p 80:80 \
  nginx:latest
```
_Source project: https://github.com/monitoringartist/vector_