### PR TITLE
Correct a metric name in the Network Retransmits widget

### DIFF
--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -595,7 +595,7 @@
                         'listendrops': 'network.tcp.listendrops',
                         'fastretrans': 'network.tcp.fastretrans',
                         'slowstartretrans': 'network.tcp.slowstartretrans',
-                        'syncretrans': 'network.tcp.syncretrans'
+                        'synretrans': 'network.tcp.synretrans'
                     }
                 },
                 size: {


### PR DESCRIPTION
Stumbled into this one thanks to some notes from Henry;
there was a rogue "c" in "network.tcp.synretrans" use.