### PR TITLE
Add four new flame graph types

### DIFF
--- a/src/app/components/diskioflamegraphtask/diskioflamegraph-help.html
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph-help.html
@@ -18,6 +18,9 @@
 
 <p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
 
+<p><b>Missing frames:</b> This shows the native stack trace, after inlining. Runtimes like the JVM can inline as much as 70% of all frames, which will be missing from the fla
+me graph. Vector has an uninlined CPU flame graph task that can reveal these missing frames.</p>
+
 <p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
 
 <h4>Externel Resources</h4>

--- a/src/app/components/diskioflamegraphtask/diskioflamegraph-help.html
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph-help.html
@@ -1,0 +1,28 @@
+<h4>Summary</h4>
+
+<p>Disk I/O flame graphs visualize code that directly requested disk I/O, helping explain the cause of disk I/O. This widget works by tracing whenever a disk I/O event is enqueued. It runs as a background task until the profile is completed.<p>
+
+<h4>Overhead</h4>
+
+<p>This should have low overhead while tracing, and then a short period (seconds) of a single CPU runtime at the end as symbols are collected and the flame graph is generated. Relative to other events, disk I/O is usually a low rate activity, hence the low overhead. There are some exceptions: a large database server may be calling tens of thousands of disk I/O per second, which will have a higher overhead to trace, not just for the extra CPU cycles, but also for the file system and storage I/O to store the trace data. If you suspect you have a high overhead case, test and measure overhead before production use.</p>
+
+<h4>Disk I/O Tracing</h4>
+
+<p>The intent here is to show which code paths are causing disk I/O. It workes by tracing when disk I/O events are inserted on a storage queue to be later issued to the device. (This uses the Linux tracepoint: block:block_rq_insert.) This approach is simple and usually identifies the code path of interest. There are worse approaches: for example, mesauring when the disk I/O actually begins, which is often asynchronous to the request, and so does not identify the code path of interest.</p>
+
+<h4>Flame Graph Visualization</h4>
+
+<p>The x-axis shows the stack profile population, sorted alphabetically (it is not the passage of time), and the y-axis shows stack depth. Each rectangle represents a stack frame. The wider a frame is is, the more often it was present in the profile. The top edge shows what directly triggered a disk I/O request to be queued, and beneath it is its ancestry. The x-axis width is relative to the number of I/O. Different color hues are used for different code types, and the saturation is randomized to differentiate between frames.</p>
+
+<h4>Common Issues</h4>
+
+<p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
+
+<p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
+
+<h4>Externel Resources</h4>
+
+<ul>
+<li>The <a href="http://www.brendangregg.com/flamegraphs.html">Flame Graphs homepage</a> has a page on <a href="http://www.brendangregg.com/FlameGraphs/memoryflamegraphs.html">Memory Flame Graphs</a>, which includes a section on page fault tracing.</li>
+<li>There is an ACMQ article <a href="http://queue.acm.org/detail.cfm?id=2927301">The Flame Graph</a>, also published in <a href="http://cacm.acm.org/magazines/2016/6/202665-the-flame-graph/abstract">CACM</a>.</li>
+</ul>

--- a/src/app/components/diskioflamegraphtask/diskioflamegraph.directive.js
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph.directive.js
@@ -1,0 +1,92 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function () {
+    'use strict';
+
+    function diskioFlameGraph($rootScope, $timeout, DiskIOFlameGraphService, DashboardService) {
+
+        function link(scope) {
+            scope.host = $rootScope.properties.host;
+            scope.port = $rootScope.properties.port;
+            scope.context = $rootScope.properties.context;
+            scope.ready = false;
+            scope.processing = false;
+            scope.id = DashboardService.getGuid();
+            scope.svgname = "error.svg";
+            scope.statusmsg = "";
+            scope.waited = 0;
+            scope.pollms = 2000;
+            scope.waitedmax = 10 * 60 * 1000;   // max poll milliseconds
+            scope.secondoptions = ["5", "30", "60", "120"];
+            scope.secondselected = "60";
+            scope.widget.help_url = "app/components/diskioflamegraphtask/diskioflamegraph-help.html";
+
+            scope.pollStatus = function() {
+                DiskIOFlameGraphService.pollStatus(function(statusmsg) {
+                    scope.statusmsg = statusmsg;
+                    scope.waited += scope.pollms;
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "DONE" || fields[0] == "ERROR" || scope.waited > scope.waitedmax) {
+                        if (scope.waited > scope.waitedmax)
+                            scope.statusmsg = "Error, timed out";
+                        if (fields[0] == "DONE") {
+                            scope.statusmsg = "DONE";
+                            scope.svgname = fields[1];
+                            scope.processing = false;
+                        }
+                        if (fields[0] == "ERROR") {
+                            scope.ready = false;
+                            scope.processing = false;
+                        }
+                    } else {
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+
+            scope.generateDiskIOFlameGraph = function() {
+                DiskIOFlameGraphService.generate(scope.secondselected, function(statusmsg) {
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "ERROR") {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = false;
+                        scope.processing = false;
+                        // don't launch poll
+                    } else {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = true;
+                        scope.processing = true;
+                        scope.waited = 0;
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+        }
+
+        return {
+            restrict: 'A',
+            templateUrl: 'app/components/diskioflamegraphtask/diskioflamegraph.html',
+            link: link
+        };
+    }
+
+    angular
+        .module('diskioflamegraphtask')
+        .directive('diskioFlameGraph', diskioFlameGraph);
+
+})();

--- a/src/app/components/diskioflamegraphtask/diskioflamegraph.html
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph.html
@@ -1,0 +1,13 @@
+<div class="col-md-12">
+    <div class="row" style="text-align: center;">
+        <p>Disk I/O stack tracing</p>
+        <button type="button" class="btn btn-primary" ng-disabled="processing" ng-click="generateDiskIOFlameGraph()">Generate Disk I/O Flame Graph<i ng-if="processing" class="fa fa-refresh fa-spin"></i></button>
+    seconds: <select class="select" ng-model="secondselected" style="margin-top:7px"><option ng-repeat="x in secondoptions">{{x}}</option></select>
+    </div>
+    <div class="row" style="margin-top: 10px;">Status: {{statusmsg}}</div>
+    <div class="row" ng-if="!processing && ready" style="text-align: center; margin-top: 15px;">
+        <p>The flame graph is ready. Please click on the button below to open it.</p>
+        <a class="btn btn-default" href="http://{{host}}:{{port}}/{{svgname}}" target="_blank">Open Flame Graph</a>
+    </div>
+
+</div>

--- a/src/app/components/diskioflamegraphtask/diskioflamegraph.module.js
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph.module.js
@@ -1,0 +1,26 @@
+/**!
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function() {
+  'use strict';
+
+  angular
+    .module('diskioflamegraphtask', [
+       'dashboard'
+    ]);
+
+})();

--- a/src/app/components/diskioflamegraphtask/diskioflamegraph.service.js
+++ b/src/app/components/diskioflamegraphtask/diskioflamegraph.service.js
@@ -1,0 +1,63 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+ (function () {
+     'use strict';
+
+     /**
+     * @name DiskIOFlameGraphService
+     */
+     function DiskIOFlameGraphService($log, $rootScope, $http, toastr) {
+
+        /**
+        * @name generate
+        * @desc
+        */
+        function generate(seconds, poll) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_store?name=vector.task.diskioflamegraph&value=' + seconds)
+                .success(function () {
+                    toastr.success('vector.task.diskioflamegraph requested.', 'Success');
+                    poll("REQUESTED");
+                }).error(function (err) {
+                    toastr.error('Failed requesting vector.task.diskioflamegraph: ' + err, 'Error');
+                    poll("ERROR " + err);
+                });
+        }
+
+        function pollStatus(refresh) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_fetch?names=vector.task.diskioflamegraph')
+                .success(function (data) {
+                    if (angular.isDefined(data.values[0])) {
+                        var message = data.values[0].instances[0].value;
+                        refresh(message);
+                    }
+                }).error(function () {
+                        refresh("ERROR fetching status");
+                });
+        }
+
+        return {
+            generate: generate,
+            pollStatus: pollStatus
+        };
+    }
+
+    angular
+        .module('diskioflamegraphtask')
+        .factory('DiskIOFlameGraphService', DiskIOFlameGraphService);
+
+ })();

--- a/src/app/components/flamegraph/flamegraph-help.html
+++ b/src/app/components/flamegraph/flamegraph-help.html
@@ -18,6 +18,8 @@
 
 <p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
 
+<p><b>Missing frames:</b> This shows the native stack trace, after inlining. Runtimes like the JVM can inline as much as 70% of all frames, which will be missing from the flame graph. Vector has an uninlined CPU flame graph task that can reveal these missing frames.</p>
+
 <p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
 
 <h4>Externel Resources</h4>

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph-help.html
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph-help.html
@@ -1,0 +1,31 @@
+<h4>Summary</h4>
+
+<p>Page fault flame graphs visualize code that is triggering page faults, which can explain application memory growth (the growth of resident set size: RSS). This widget works by tracing page faults on all running CPUs. It runs as a background task until the profile is completed.<p>
+
+<h4>Overhead</h4>
+
+<p>This should have low overhead while tracing, and then a short period (seconds) of a single CPU runtime at the end as symbols are collected and the flame graph generated. Page faults are usually a low rate activity, hence the low overhead. There are some exceptions: software builds that use hundreds of short-lived processes per second can have a much higher rate of page faults, as well as applications that are growing RSS quickly. In such cases, this task may have a higher overhead, not just for the extra CPU cycles, but also for the file system and storage I/O to store the trace data. If you suspect you have a high overhead case, test and measure overhead before production use.</p>
+
+<h4>Page Fault Tracing</h4>
+
+<p>This is one way to analyze memory growth, in this case, the growth of resident set size (RSS).</p>
+<p>Linux (like most operating systems) uses on-demand memory page allocation. When an application allocates memory (eg, malloc()), the operating system tracks the allocation but does not map physical memory to the process until it begins writing to it. At that point, the lie is revealed, and the processor's memory manangement unit (MMU) will "fault", as there is no virtual-to-physical mapping for the requested address. The kernel handles the fault, and makes the mapping. This is a normal way that processes end up using main memory, and defers the cost of allocation to later on, and only for the pages (unit of memory) that are written to.</p>
+<p>Some applications pre-allocate memory (by which they mean touch it all &ndash; they write to it on startup so that it has mapped to physical memory). In those cases, RSS should be static, and this flame graph won't show many trace application events.</p>
+<p>To be clear about this: page fault tracing can explain memory growth where the application may end up being out-of-memory (OOM) killed. It usually can't explain memory leaks where the application ends up calling garbage collection more frequently, since in those cases the application may or may not be growing RSS. This can only see RSS growth.</p>
+
+<h4>Flame Graph Visualization</h4>
+
+<p>The x-axis shows the stack profile population, sorted alphabetically (it is not the passage of time), and the y-axis shows stack depth. Each rectangle represents a stack frame. The wider a frame is is, the more often it was present in the profile. The top edge shows what directly triggered page faults, and beneath it is its ancestry. Different color hues are used for different code types, and the saturation is randomized to differentiate between frames.</p>
+
+<h4>Common Issues</h4>
+
+<p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
+
+<p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
+
+<h4>Externel Resources</h4>
+
+<ul>
+<li>The <a href="http://www.brendangregg.com/flamegraphs.html">Flame Graphs homepage</a> has a page on <a href="http://www.brendangregg.com/FlameGraphs/memoryflamegraphs.html">Memory Flame Graphs</a>, which includes a section on page fault tracing.</li>
+<li>There is an ACMQ article <a href="http://queue.acm.org/detail.cfm?id=2927301">The Flame Graph</a>, also published in <a href="http://cacm.acm.org/magazines/2016/6/202665-the-flame-graph/abstract">CACM</a>.</li>
+</ul>

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph-help.html
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph-help.html
@@ -21,6 +21,9 @@
 
 <p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
 
+<p><b>Missing frames:</b> This shows the native stack trace, after inlining. Runtimes like the JVM can inline as much as 70% of all frames, which will be missing from the fla
+me graph. Vector has an uninlined CPU flame graph task that can reveal these missing frames.</p>
+
 <p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
 
 <h4>Externel Resources</h4>

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.directive.js
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.directive.js
@@ -1,0 +1,92 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function () {
+    'use strict';
+
+    function pagefaultFlameGraph($rootScope, $timeout, PagefaultFlameGraphService, DashboardService) {
+
+        function link(scope) {
+            scope.host = $rootScope.properties.host;
+            scope.port = $rootScope.properties.port;
+            scope.context = $rootScope.properties.context;
+            scope.ready = false;
+            scope.processing = false;
+            scope.id = DashboardService.getGuid();
+            scope.svgname = "error.svg";
+            scope.statusmsg = "";
+            scope.waited = 0;
+            scope.pollms = 2000;
+            scope.waitedmax = 10 * 60 * 1000;   // max poll milliseconds
+            scope.secondoptions = ["5", "30", "60", "120"];
+            scope.secondselected = "60";
+            scope.widget.help_url = "app/components/pagefaultflamegraphtask/pagefaultflamegraph-help.html";
+
+            scope.pollStatus = function() {
+                PagefaultFlameGraphService.pollStatus(function(statusmsg) {
+                    scope.statusmsg = statusmsg;
+                    scope.waited += scope.pollms;
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "DONE" || fields[0] == "ERROR" || scope.waited > scope.waitedmax) {
+                        if (scope.waited > scope.waitedmax)
+                            scope.statusmsg = "Error, timed out";
+                        if (fields[0] == "DONE") {
+                            scope.statusmsg = "DONE";
+                            scope.svgname = fields[1];
+                            scope.processing = false;
+                        }
+                        if (fields[0] == "ERROR") {
+                            scope.ready = false;
+                            scope.processing = false;
+                        }
+                    } else {
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+
+            scope.generatePagefaultFlameGraph = function() {
+                PagefaultFlameGraphService.generate(scope.secondselected, function(statusmsg) {
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "ERROR") {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = false;
+                        scope.processing = false;
+                        // don't launch poll
+                    } else {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = true;
+                        scope.processing = true;
+                        scope.waited = 0;
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+        }
+
+        return {
+            restrict: 'A',
+            templateUrl: 'app/components/pagefaultflamegraphtask/pagefaultflamegraph.html',
+            link: link
+        };
+    }
+
+    angular
+        .module('pagefaultflamegraphtask')
+        .directive('pagefaultFlameGraph', pagefaultFlameGraph);
+
+})();

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.html
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.html
@@ -1,0 +1,13 @@
+<div class="col-md-12">
+    <div class="row" style="text-align: center;">
+        <p>Page fault stack tracing</p>
+        <button type="button" class="btn btn-primary" ng-disabled="processing" ng-click="generatePagefaultFlameGraph()">Generate Pagefault Flame Graph<i ng-if="processing" class="fa fa-refresh fa-spin"></i></button>
+    seconds: <select class="select" ng-model="secondselected" style="margin-top:7px"><option ng-repeat="x in secondoptions">{{x}}</option></select>
+    </div>
+    <div class="row" style="margin-top: 10px;">Status: {{statusmsg}}</div>
+    <div class="row" ng-if="!processing && ready" style="text-align: center; margin-top: 15px;">
+        <p>The flame graph is ready. Please click on the button below to open it.</p>
+        <a class="btn btn-default" href="http://{{host}}:{{port}}/{{svgname}}" target="_blank">Open Flame Graph</a>
+    </div>
+
+</div>

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.module.js
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.module.js
@@ -1,0 +1,26 @@
+/**!
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function() {
+  'use strict';
+
+  angular
+    .module('pagefaultflamegraphtask', [
+       'dashboard'
+    ]);
+
+})();

--- a/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.service.js
+++ b/src/app/components/pagefaultflamegraphtask/pagefaultflamegraph.service.js
@@ -1,0 +1,63 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+ (function () {
+     'use strict';
+
+     /**
+     * @name PagefaultFlameGraphService
+     */
+     function PagefaultFlameGraphService($log, $rootScope, $http, toastr) {
+
+        /**
+        * @name generate
+        * @desc
+        */
+        function generate(seconds, poll) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_store?name=vector.task.pagefaultflamegraph&value=' + seconds)
+                .success(function () {
+                    toastr.success('vector.task.pagefaultflamegraph requested.', 'Success');
+                    poll("REQUESTED");
+                }).error(function (err) {
+                    toastr.error('Failed requesting vector.task.pagefaultflamegraph: ' + err, 'Error');
+                    poll("ERROR " + err);
+                });
+        }
+
+        function pollStatus(refresh) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_fetch?names=vector.task.pagefaultflamegraph')
+                .success(function (data) {
+                    if (angular.isDefined(data.values[0])) {
+                        var message = data.values[0].instances[0].value;
+                        refresh(message);
+                    }
+                }).error(function () {
+                        refresh("ERROR fetching status");
+                });
+        }
+
+        return {
+            generate: generate,
+            pollStatus: pollStatus
+        };
+    }
+
+    angular
+        .module('pagefaultflamegraphtask')
+        .factory('PagefaultFlameGraphService', PagefaultFlameGraphService);
+
+ })();

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph-help.html
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph-help.html
@@ -1,0 +1,27 @@
+<h4>Summary</h4>
+
+<p>Package name flame graphs visualize code that is directly consuming CPUs, and visualizes this as a hierarchy from the package name (currently only supports Java package names). This widget works using a profiler that does timed sampling of the instruction pointer at 49 Hertz, on all running CPUs. It runs as a background task until the profile is completed.<p>
+
+<h4>Overhead</h4>
+
+<p>This should have negligible overhead while profiling, and then a short period (seconds) of a single CPU runtime at the end as symbols are collected and the flame graph generated.</p>
+
+<h4>CPU IP Profiling</h4>
+
+<p>Timed sampling of the instruction pointer (aka program counter) is a common industry method for understanding CPU usage with very low overhead. This is different to tracing of all functions/methods, which is performed by some CPU profilers and costs high overhead and often skews results (observer effect). This is also different to profiling stack traces, as is typical with flame graphs. In this case, the stack trace is not collected, so code ancestry is not known or shown. The advantage is a different view of CPU consumption, that can be used in addition to normal flame graphs.</p>
+
+<h4>Flame Graph Visualization</h4>
+
+<p>The x-axis shows the stack profile population, sorted alphabetically (it is not the passage of time), and the y-axis in this case traverses components of the function or method package name. Each rectangle represents a component of the function or method name. The wider a frame is is, the more often it was present in the profile. The top edge shows the functions that are on-CPu, and beneath them are the larger package groups that they belong to. Different color hues are used for different code types, and the saturation is randomized to differentiate between frames.</p>
+
+<h4>Common Issues</h4>
+
+<p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
+
+<h4>Externel Resources</h4>
+
+<ul>
+<li>A post on <a href="http://www.brendangregg.com/blog/2017-06-30/package-flame-graph.html">Package Name Flame Graphs</a>.</li>
+<li>The <a href="http://www.brendangregg.com/flamegraphs.html">Flame Graphs homepage</a>.</li>
+<li>An ACMQ article <a href="http://queue.acm.org/detail.cfm?id=2927301">The Flame Graph</a>, also published in <a href="http://cacm.acm.org/magazines/2016/6/202665-the-flame-graph/abstract">CACM</a>.</li>
+</ul>

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph-help.html
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph-help.html
@@ -1,6 +1,6 @@
 <h4>Summary</h4>
 
-<p>Package name flame graphs visualize code that is directly consuming CPUs, and visualizes this as a hierarchy from the package name (currently only supports Java package names). This widget works using a profiler that does timed sampling of the instruction pointer at 49 Hertz, on all running CPUs. It runs as a background task until the profile is completed.<p>
+<p>Package name flame graphs visualize code that is directly consuming CPUs, and visualizes this as a hierarchy based on the package name (currently only supports Java package names). This widget works using a profiler that does timed sampling of the instruction pointer at 49 Hertz, on all running CPUs. This does not need the application to support stack traces, as it only measures the running function (ie, for Java, this does not need -XX:+PreserveFramePointer, so this can be useful for analyzing applications that are running without it). It runs as a background task until the profile is completed.<p>
 
 <h4>Overhead</h4>
 

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.directive.js
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.directive.js
@@ -1,0 +1,92 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function () {
+    'use strict';
+
+    function pNameCpuFlameGraph($rootScope, $timeout, PNameCPUFlameGraphService, DashboardService) {
+
+        function link(scope) {
+            scope.host = $rootScope.properties.host;
+            scope.port = $rootScope.properties.port;
+            scope.context = $rootScope.properties.context;
+            scope.ready = false;
+            scope.processing = false;
+            scope.id = DashboardService.getGuid();
+            scope.svgname = "error.svg";
+            scope.statusmsg = "";
+            scope.waited = 0;
+            scope.pollms = 2000;
+            scope.waitedmax = 10 * 60 * 1000;   // max poll milliseconds
+            scope.secondoptions = ["5", "30", "60", "120"];
+            scope.secondselected = "60";
+            scope.widget.help_url = "app/components/pnamecpuflamegraphtask/pnamecpuflamegraph-help.html";
+
+            scope.pollStatus = function() {
+                PNameCPUFlameGraphService.pollStatus(function(statusmsg) {
+                    scope.statusmsg = statusmsg;
+                    scope.waited += scope.pollms;
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "DONE" || fields[0] == "ERROR" || scope.waited > scope.waitedmax) {
+                        if (scope.waited > scope.waitedmax)
+                            scope.statusmsg = "Error, timed out";
+                        if (fields[0] == "DONE") {
+                            scope.statusmsg = "DONE";
+                            scope.svgname = fields[1];
+                            scope.processing = false;
+                        }
+                        if (fields[0] == "ERROR") {
+                            scope.ready = false;
+                            scope.processing = false;
+                        }
+                    } else {
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+
+            scope.generatePNameCPUFlameGraph = function() {
+                PNameCPUFlameGraphService.generate(scope.secondselected, function(statusmsg) {
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "ERROR") {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = false;
+                        scope.processing = false;
+                        // don't launch poll
+                    } else {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = true;
+                        scope.processing = true;
+                        scope.waited = 0;
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+        }
+
+        return {
+            restrict: 'A',
+            templateUrl: 'app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.html',
+            link: link
+        };
+    }
+
+    angular
+        .module('pnamecpuflamegraphtask')
+        .directive('pNameCpuFlameGraph', pNameCpuFlameGraph);
+
+})();

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.html
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.html
@@ -1,0 +1,13 @@
+<div class="col-md-12">
+    <div class="row" style="text-align: center;">
+        <p>Timed CPU IP sampling</p>
+        <button type="button" class="btn btn-primary" ng-disabled="processing" ng-click="generatePNameCPUFlameGraph()">Generate Package Name CPU Flame Graph<i ng-if="processing" class="fa fa-refresh fa-spin"></i></button>
+    seconds: <select class="select" ng-model="secondselected" style="margin-top:7px"><option ng-repeat="x in secondoptions">{{x}}</option></select>
+    </div>
+    <div class="row" style="margin-top: 10px;">Status: {{statusmsg}}</div>
+    <div class="row" ng-if="!processing && ready" style="text-align: center; margin-top: 15px;">
+        <p>The CPU flame graph is ready. Please click on the button below to open it.</p>
+        <a class="btn btn-default" href="http://{{host}}:{{port}}/{{svgname}}" target="_blank">Open Flame Graph</a>
+    </div>
+
+</div>

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.module.js
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.module.js
@@ -1,0 +1,26 @@
+/**!
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function() {
+  'use strict';
+
+  angular
+    .module('pnamecpuflamegraphtask', [
+       'dashboard'
+    ]);
+
+})();

--- a/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.service.js
+++ b/src/app/components/pnamecpuflamegraphtask/pnamecpuflamegraph.service.js
@@ -1,0 +1,63 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+ (function () {
+     'use strict';
+
+     /**
+     * @name PNameCPUFlameGraphService
+     */
+     function PNameCPUFlameGraphService($log, $rootScope, $http, toastr) {
+
+        /**
+        * @name generate
+        * @desc
+        */
+        function generate(seconds, poll) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_store?name=vector.task.pnamecpuflamegraph&value=' + seconds)
+                .success(function () {
+                    toastr.success('vector.task.pnamecpuflamegraph requested.', 'Success');
+                    poll("REQUESTED");
+                }).error(function (err) {
+                    toastr.error('Failed requesting vector.task.pnamecpuflamegraph: ' + err, 'Error');
+                    poll("ERROR " + err);
+                });
+        }
+
+        function pollStatus(refresh) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_fetch?names=vector.task.pnamecpuflamegraph')
+                .success(function (data) {
+                    if (angular.isDefined(data.values[0])) {
+                        var message = data.values[0].instances[0].value;
+                        refresh(message);
+                    }
+                }).error(function () {
+                        refresh("ERROR fetching status");
+                });
+        }
+
+        return {
+            generate: generate,
+            pollStatus: pollStatus
+        };
+    }
+
+    angular
+        .module('pnamecpuflamegraphtask')
+        .factory('PNameCPUFlameGraphService', PNameCPUFlameGraphService);
+
+ })();

--- a/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph-help.html
+++ b/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph-help.html
@@ -1,0 +1,28 @@
+<h4>Summary</h4>
+
+<p>Uninlined CPU flame graphs visualize code that is consuming CPUs, and attempts to uninline application frames so that full stacks are shown (currently only supports Java). This widget works using a profiler that does timed sampling of stack traces at 49 Hertz, on all running CPUs. It runs as a background task until the profile is completed.<p>
+
+<h4>Overhead</h4>
+
+<p>This should have negligible overhead while profiling, and then a short period (seconds) of a single CPU runtime at the end as symbols are collected and the flame graph generated.</p>
+
+<h4>CPU Profiling</h4>
+
+<p>Timed sampling of stack traces is a common industry method for understanding CPU usage with low overhead. This is different to tracing of all functions/methods, which is performed by some CPU profilers and costs high overhead and often skews results (observer effect).</p>
+
+<h4>Flame Graph Visualization</h4>
+
+<p>The x-axis shows the stack profile population, sorted alphabetically (it is not the passage of time), and the y-axis shows stack depth. Each rectangle represents a stack frame. The wider a frame is is, the more often it was present in the profile. The top edge shows what is on-CPU, and beneath it is its ancestry. Different color hues are used for different code types, and the saturation is randomized to differentiate between frames.</p>
+
+<h4>Common Issues</h4>
+
+<p><b>Broken stacks:</b> If the runtime does not expose a stack walker that the profiler can use (commonly frame-pointer based), then stack traces will be broken and ancestry will be missing. This is usually visible as a "bed of grass": thin frames all at the same level. The fix depends on the runtime and stack walking technique. Eg, to use frame-pointer walking with Java, Java must be run with -XX:+PreserveFramePointer.</p>
+
+<p><b>Missing symbols:</b> JIT runtimes need to export a symbol file for the profiler to use. This depends on the runtime. Java should be handled automatically by Vector, making use of perf-map-agent. Node.js currently needs to run with --perf_basic_prof_only_funcitons or --perf_basic_prof.</p>
+
+<h4>Externel Resources</h4>
+
+<ul>
+<li>The <a href="http://www.brendangregg.com/flamegraphs.html">Flame Graphs homepage</a> has a page on <a href="http://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html">CPU Flame Graphs</a>.</li>
+<li>There is an ACMQ article <a href="http://queue.acm.org/detail.cfm?id=2927301">The Flame Graph</a>, also published in <a href="http://cacm.acm.org/magazines/2016/6/202665-the-flame-graph/abstract">CACM</a>.</li>
+</ul>

--- a/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.directive.js
+++ b/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.directive.js
@@ -1,0 +1,92 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function () {
+    'use strict';
+
+    function uninlinedCpuFlameGraph($rootScope, $timeout, UninlinedCPUFlameGraphService, DashboardService) {
+
+        function link(scope) {
+            scope.host = $rootScope.properties.host;
+            scope.port = $rootScope.properties.port;
+            scope.context = $rootScope.properties.context;
+            scope.ready = false;
+            scope.processing = false;
+            scope.id = DashboardService.getGuid();
+            scope.svgname = "error.svg";
+            scope.statusmsg = "";
+            scope.waited = 0;
+            scope.pollms = 2000;
+            scope.waitedmax = 10 * 60 * 1000;   // max poll milliseconds
+            scope.secondoptions = ["5", "30", "60", "120"];
+            scope.secondselected = "60";
+            scope.widget.help_url = "app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph-help.html";
+
+            scope.pollStatus = function() {
+                UninlinedCPUFlameGraphService.pollStatus(function(statusmsg) {
+                    scope.statusmsg = statusmsg;
+                    scope.waited += scope.pollms;
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "DONE" || fields[0] == "ERROR" || scope.waited > scope.waitedmax) {
+                        if (scope.waited > scope.waitedmax)
+                            scope.statusmsg = "Error, timed out";
+                        if (fields[0] == "DONE") {
+                            scope.statusmsg = "DONE";
+                            scope.svgname = fields[1];
+                            scope.processing = false;
+                        }
+                        if (fields[0] == "ERROR") {
+                            scope.ready = false;
+                            scope.processing = false;
+                        }
+                    } else {
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+
+            scope.generateUninlinedCPUFlameGraph = function() {
+                UninlinedCPUFlameGraphService.generate(scope.secondselected, function(statusmsg) {
+                    var fields = statusmsg.split(" ");
+                    if (fields[0] == "ERROR") {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = false;
+                        scope.processing = false;
+                        // don't launch poll
+                    } else {
+                        scope.statusmsg = statusmsg;
+                        scope.ready = true;
+                        scope.processing = true;
+                        scope.waited = 0;
+                        $timeout(function () { scope.pollStatus(); }, scope.pollms);
+                    }
+                });
+            };
+        }
+
+        return {
+            restrict: 'A',
+            templateUrl: 'app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.html',
+            link: link
+        };
+    }
+
+    angular
+        .module('uninlinedcpuflamegraphtask')
+        .directive('uninlinedCpuFlameGraph', uninlinedCpuFlameGraph);
+
+})();

--- a/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.html
+++ b/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.html
@@ -1,0 +1,13 @@
+<div class="col-md-12">
+    <div class="row" style="text-align: center;">
+        <p>Timed CPU stack sampling</p>
+        <button type="button" class="btn btn-primary" ng-disabled="processing" ng-click="generateUninlinedCPUFlameGraph()">Generate Uninlined CPU Flame Graph<i ng-if="processing" class="fa fa-refresh fa-spin"></i></button>
+    seconds: <select class="select" ng-model="secondselected" style="margin-top:7px"><option ng-repeat="x in secondoptions">{{x}}</option></select>
+    </div>
+    <div class="row" style="margin-top: 10px;">Status: {{statusmsg}}</div>
+    <div class="row" ng-if="!processing && ready" style="text-align: center; margin-top: 15px;">
+        <p>The CPU flame graph is ready. Please click on the button below to open it.</p>
+        <a class="btn btn-default" href="http://{{host}}:{{port}}/{{svgname}}" target="_blank">Open Flame Graph</a>
+    </div>
+
+</div>

--- a/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.module.js
+++ b/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.module.js
@@ -1,0 +1,26 @@
+/**!
+ *
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+(function() {
+  'use strict';
+
+  angular
+    .module('uninlinedcpuflamegraphtask', [
+       'dashboard'
+    ]);
+
+})();

--- a/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.service.js
+++ b/src/app/components/uninlinedcpuflamegraphtask/uninlinedcpuflamegraph.service.js
@@ -1,0 +1,63 @@
+/**!
+ *
+ *  Copyright 2015 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+ (function () {
+     'use strict';
+
+     /**
+     * @name UninlinedCPUFlameGraphService
+     */
+     function UninlinedCPUFlameGraphService($log, $rootScope, $http, toastr) {
+
+        /**
+        * @name generate
+        * @desc
+        */
+        function generate(seconds, poll) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_store?name=vector.task.uninlinedcpuflamegraph&value=' + seconds)
+                .success(function () {
+                    toastr.success('vector.task.uninlinedcpuflamegraph requested.', 'Success');
+                    poll("REQUESTED");
+                }).error(function (err) {
+                    toastr.error('Failed requesting vector.task.uninlinedcpuflamegraph: ' + err, 'Error');
+                    poll("ERROR " + err);
+                });
+        }
+
+        function pollStatus(refresh) {
+            $http.get($rootScope.properties.protocol + '://' + $rootScope.properties.host + ':' + $rootScope.properties.port + '/pmapi/' + $rootScope.properties.context + '/_fetch?names=vector.task.uninlinedcpuflamegraph')
+                .success(function (data) {
+                    if (angular.isDefined(data.values[0])) {
+                        var message = data.values[0].instances[0].value;
+                        refresh(message);
+                    }
+                }).error(function () {
+                        refresh("ERROR fetching status");
+                });
+        }
+
+        return {
+            generate: generate,
+            pollStatus: pollStatus
+        };
+    }
+
+    angular
+        .module('uninlinedcpuflamegraphtask')
+        .factory('UninlinedCPUFlameGraphService', UninlinedCPUFlameGraphService);
+
+ })();

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -633,8 +633,9 @@
 
         if (config.enableCpuFlameGraph) {
           definitions.push({
+            /* for legacy, CPU flame graphs are in the CPU menu as well */
             name: 'graph.flame.cpu',
-            title: 'CPU Flame Graph',
+            title: 'CPU Flame Graph (task)',
             directive: 'cpu-flame-graph',
             dataModelType: DummyMetricDataModel,
             size: {
@@ -643,6 +644,38 @@
             },
             enableVerticalResize: false,
             group: 'CPU',
+            settingsModalOptions: {
+                templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
+                controller: 'CustomWidgetHelpController'
+            },
+            hasLocalHelp: true
+          }, {
+            name: 'graph.flame.cpu.task',
+            title: 'CPU Flame Graph (task)',
+            directive: 'cpu-flame-graph',
+            dataModelType: DummyMetricDataModel,
+            size: {
+              width: '50%',
+              height: '250px'
+            },
+            enableVerticalResize: false,
+            group: 'Task',
+            settingsModalOptions: {
+                templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
+                controller: 'CustomWidgetHelpController'
+            },
+            hasLocalHelp: true
+          }, {
+            name: 'graph.flame.pnamecpu.task',
+            title: 'Package Name CPU Flame Graph (task)',
+            directive: 'p-name-cpu-flame-graph',
+            dataModelType: DummyMetricDataModel,
+            size: {
+              width: '50%',
+              height: '250px'
+            },
+            enableVerticalResize: false,
+            group: 'Task',
             settingsModalOptions: {
                 templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
                 controller: 'CustomWidgetHelpController'
@@ -1046,6 +1079,7 @@
             'datamodel',
             'chart',
             'flamegraph',
+            'pnamecpuflamegraphtask',
             'customWidgetSettings',
             'customWidgetHelp'
         ])

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -681,6 +681,22 @@
                 controller: 'CustomWidgetHelpController'
             },
             hasLocalHelp: true
+          }, {
+            name: 'graph.flame.uninlined.task',
+            title: 'Uninlined CPU Flame Graph (task)',
+            directive: 'uninlined-cpu-flame-graph',
+            dataModelType: DummyMetricDataModel,
+            size: {
+              width: '50%',
+              height: '250px'
+            },
+            enableVerticalResize: false,
+            group: 'Task',
+            settingsModalOptions: {
+                templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
+                controller: 'CustomWidgetHelpController'
+            },
+            hasLocalHelp: true
           });
         }
 
@@ -1080,6 +1096,7 @@
             'chart',
             'flamegraph',
             'pnamecpuflamegraphtask',
+            'uninlinedcpuflamegraphtask',
             'customWidgetSettings',
             'customWidgetHelp'
         ])

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -697,6 +697,22 @@
                 controller: 'CustomWidgetHelpController'
             },
             hasLocalHelp: true
+          }, {
+            name: 'graph.flame.pagefault.task',
+            title: 'Page Fault Flame Graph (task)',
+            directive: 'pagefault-flame-graph',
+            dataModelType: DummyMetricDataModel,
+            size: {
+              width: '50%',
+              height: '250px'
+            },
+            enableVerticalResize: false,
+            group: 'Task',
+            settingsModalOptions: {
+                templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
+                controller: 'CustomWidgetHelpController'
+            },
+            hasLocalHelp: true
           });
         }
 
@@ -1097,6 +1113,7 @@
             'flamegraph',
             'pnamecpuflamegraphtask',
             'uninlinedcpuflamegraphtask',
+            'pagefaultflamegraphtask',
             'customWidgetSettings',
             'customWidgetHelp'
         ])

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -713,6 +713,22 @@
                 controller: 'CustomWidgetHelpController'
             },
             hasLocalHelp: true
+          }, {
+            name: 'graph.flame.diskio.task',
+            title: 'Disk I/O Flame Graph (task)',
+            directive: 'diskio-flame-graph',
+            dataModelType: DummyMetricDataModel,
+            size: {
+              width: '50%',
+              height: '250px'
+            },
+            enableVerticalResize: false,
+            group: 'Task',
+            settingsModalOptions: {
+                templateUrl: 'app/components/customWidgetHelp/customWidgetHelp.html',
+                controller: 'CustomWidgetHelpController'
+            },
+            hasLocalHelp: true
           });
         }
 
@@ -1114,6 +1130,7 @@
             'pnamecpuflamegraphtask',
             'uninlinedcpuflamegraphtask',
             'pagefaultflamegraphtask',
+            'diskioflamegraphtask',
             'customWidgetSettings',
             'customWidgetHelp'
         ])


### PR DESCRIPTION
- vector.task.pnamecpuflamegraph: Profile CPU instruction pointer and create a package name flame graph.
- vector.task.uninlinedcpuflamegraph: Profile CPU stack traces with some uninlining for a flame graph.
- vector.task.pagefaultflamegraph: Trace page faults with stacks and create a flame graph.
- vector.task.diskioflamegraph: Trace disk I/O issues with stacks and create a flame graph.