### PR TITLE
Fix the gulp build for node version 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .sass-cache/
 npm-debug.log
 src/app/index.version.js
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-eslint": "~1.0.0",
     "gulp-filter": "~3.0.1",
     "gulp-flatten": "~0.2.0",
-    "gulp-git": "^1.7.1",
+    "gulp-git": "~2.4.2",
     "gulp-htmlmin": "~1.3.0",
     "gulp-inject": "~3.0.0",
     "gulp-lintspaces": "^0.4.1",


### PR DESCRIPTION
On node v8+ I'm seeing the build failure below, which
appears to be due to now-deprecated javascript code
that is contained within require-dir, which vector is
importing via gulp-git.

/source/git/vector/node_modules/require-dir/index.js:93
            if (!require.extensions.hasOwnProperty(ext)) {
                                    ^

TypeError: require.extensions.hasOwnProperty is not a function
    at requireDir (/source/git/vector/node_modules/require-dir/index.js:93:37)
    at Object.<anonymous> (/source/git/vector/node_modules/gulp-git/index.js:4:18)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/source/git/vector/gulp/scripts.js:7:11)