### PR TITLE
Add PCP BCC PMDA hit count module widgets

### DIFF
--- a/src/app/components/datamodel/bccTracepointhitsMetric.datamodel.factory.js
+++ b/src/app/components/datamodel/bccTracepointhitsMetric.datamodel.factory.js
@@ -1,0 +1,64 @@
+/**!
+ *
+ *  Copyright (C) 2018 Marko Myllynen <myllynen@redhat.com>
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * @name BccTracepointhitsMetricDataModel
+   * @desc
+   */
+  function BccTracepointhitsMetricDataModel(WidgetDataModel, MetricListService, DashboardService) {
+    var DataModel = function () {
+      return this;
+    };
+
+    DataModel.prototype = Object.create(WidgetDataModel.prototype);
+
+    DataModel.prototype.init = function () {
+      WidgetDataModel.prototype.init.call(this);
+
+      this.name = this.dataModelOptions ? this.dataModelOptions.name : 'metric_' + DashboardService.getGuid();
+      this.tableDefinition = {
+        columns: [
+          {label: 'TRACEPOINT'},
+          {label: 'HITS', css_class: 'text-right'}
+        ],
+        rowFn: function(instance, value) {
+          return [instance, value];
+        }
+      };
+
+      this.metric = MetricListService.getOrCreateMetric('bcc.tracepoint.hits');
+      this.updateScope(this.metric.data);
+    };
+
+    DataModel.prototype.destroy = function () {
+      // remove subscribers and delete base metrics
+      MetricListService.destroyMetric(this.metric.name);
+
+      WidgetDataModel.prototype.destroy.call(this);
+    };
+
+    return DataModel;
+  }
+
+  angular
+    .module('datamodel')
+    .factory('BccTracepointhitsMetricDataModel', BccTracepointhitsMetricDataModel);
+})();

--- a/src/app/components/datamodel/bccUSDThitsMetric.datamodel.factory.js
+++ b/src/app/components/datamodel/bccUSDThitsMetric.datamodel.factory.js
@@ -1,0 +1,64 @@
+/**!
+ *
+ *  Copyright (C) 2018 Marko Myllynen <myllynen@redhat.com>
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * @name BccUSDThitsMetricDataModel
+   * @desc
+   */
+  function BccUSDThitsMetricDataModel(WidgetDataModel, MetricListService, DashboardService) {
+    var DataModel = function () {
+      return this;
+    };
+
+    DataModel.prototype = Object.create(WidgetDataModel.prototype);
+
+    DataModel.prototype.init = function () {
+      WidgetDataModel.prototype.init.call(this);
+
+      this.name = this.dataModelOptions ? this.dataModelOptions.name : 'metric_' + DashboardService.getGuid();
+      this.tableDefinition = {
+        columns: [
+          {label: 'USDT'},
+          {label: 'HITS', css_class: 'text-right'}
+        ],
+        rowFn: function(instance, value) {
+          return [instance, value];
+        }
+      };
+
+      this.metric = MetricListService.getOrCreateMetric('bcc.usdt.hits');
+      this.updateScope(this.metric.data);
+    };
+
+    DataModel.prototype.destroy = function () {
+      // remove subscribers and delete base metrics
+      MetricListService.destroyMetric(this.metric.name);
+
+      WidgetDataModel.prototype.destroy.call(this);
+    };
+
+    return DataModel;
+  }
+
+  angular
+    .module('datamodel')
+    .factory('BccUSDThitsMetricDataModel', BccUSDThitsMetricDataModel);
+})();

--- a/src/app/components/datamodel/bccUprobehitsMetric.datamodel.factory.js
+++ b/src/app/components/datamodel/bccUprobehitsMetric.datamodel.factory.js
@@ -1,0 +1,64 @@
+/**!
+ *
+ *  Copyright (C) 2018 Marko Myllynen <myllynen@redhat.com>
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+(function () {
+  'use strict';
+
+  /**
+   * @name BccUprobehitsMetricDataModel
+   * @desc
+   */
+  function BccUprobehitsMetricDataModel(WidgetDataModel, MetricListService, DashboardService) {
+    var DataModel = function () {
+      return this;
+    };
+
+    DataModel.prototype = Object.create(WidgetDataModel.prototype);
+
+    DataModel.prototype.init = function () {
+      WidgetDataModel.prototype.init.call(this);
+
+      this.name = this.dataModelOptions ? this.dataModelOptions.name : 'metric_' + DashboardService.getGuid();
+      this.tableDefinition = {
+        columns: [
+          {label: 'UPROBE'},
+          {label: 'HITS', css_class: 'text-right'}
+        ],
+        rowFn: function(instance, value) {
+          return [instance, value];
+        }
+      };
+
+      this.metric = MetricListService.getOrCreateMetric('bcc.uprobe.hits');
+      this.updateScope(this.metric.data);
+    };
+
+    DataModel.prototype.destroy = function () {
+      // remove subscribers and delete base metrics
+      MetricListService.destroyMetric(this.metric.name);
+
+      WidgetDataModel.prototype.destroy.call(this);
+    };
+
+    return DataModel;
+  }
+
+  angular
+    .module('datamodel')
+    .factory('BccUprobehitsMetricDataModel', BccUprobehitsMetricDataModel);
+})();

--- a/src/app/components/widget/widget.factory.js
+++ b/src/app/components/widget/widget.factory.js
@@ -50,6 +50,9 @@
         BccExecsnoopMetricDataModel,
         BccTcpretransMetricDataModel,
         BccBiotopMetricDataModel,
+        BccTracepointhitsMetricDataModel,
+        BccUSDThitsMetricDataModel,
+        BccUprobehitsMetricDataModel,
         CumulativeUtilizationMetricDataModel,
         CgroupMemoryUtilizationMetricDataModel,
         CustomMetricDataModel,
@@ -1358,6 +1361,73 @@
                     overflow: 'auto'
                 }
             });
+
+            definitions.push({
+                name: 'bcc.tracepoint.hits',
+                title: 'BCC tracepoint hits (kernel tracepoint hit counts)',
+                directive: 'table',
+                dataAttrName: 'data',
+                dataModelType: BccTracepointhitsMetricDataModel,
+                dataModelOptions: {
+                    name: 'bcc.tracepoint.hits'
+                },
+                size: {
+                    width: '50%',
+                    height: '500px'
+                },
+                enableVerticalResize: true,
+                group: 'BPF/BCC',
+                attrs: {
+                },
+                contentStyle: {
+                    overflow: 'auto'
+                }
+            });
+
+            definitions.push({
+                name: 'bcc.usdt.hits',
+                title: 'BCC USDT hits (USDT hit counts)',
+                directive: 'table',
+                dataAttrName: 'data',
+                dataModelType: BccUSDThitsMetricDataModel,
+                dataModelOptions: {
+                    name: 'bcc.usdt.hits'
+                },
+                size: {
+                    width: '50%',
+                    height: '500px'
+                },
+                enableVerticalResize: true,
+                group: 'BPF/BCC',
+                attrs: {
+                },
+                contentStyle: {
+                    overflow: 'auto'
+                }
+            });
+
+            definitions.push({
+                name: 'bcc.uprobe.hits',
+                title: 'BCC uprobe hits (uprobe hit counts)',
+                directive: 'table',
+                dataAttrName: 'data',
+                dataModelType: BccUprobehitsMetricDataModel,
+                dataModelOptions: {
+                    name: 'bcc.uprobe.hits'
+                },
+                size: {
+                    width: '50%',
+                    height: '500px'
+                },
+                enableVerticalResize: true,
+                group: 'BPF/BCC',
+                attrs: {
+                },
+                contentStyle: {
+                    overflow: 'auto'
+                }
+            });
+
         }
 
         return definitions;


### PR DESCRIPTION
PCP BCC PMDA has recently introduced support for hit count modules for
tracing hits to kernel tracepoints, USDT probes, and uprobes.

This patch adds table widgets for these modules. We use tables instead
of a graph since hit counts for different probes may vary between a few
to millions.

Below is a simple screenshot how these look like:

![screenshot](https://user-images.githubusercontent.com/24413632/42159430-64a1cef8-7dfc-11e8-8e05-e33b0cf5eea0.png)

CC @andihit 

Thanks!