### PR TITLE
Add support for the protocol to be specified against a context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .sass-cache/
 npm-debug.log
 src/app/index.version.js
+.vs/

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -158,13 +158,11 @@ class App extends React.Component {
           <Navbar embed={this.props.embed} onClick={this.toggleConfigVisible} />
 
           <ContextPoller
-            protocol={config.protocol}
             pollIntervalMs={5000}
             targets={this.state.targets}
             onContextsUpdated={this.onContextsUpdated} />
 
           <DatasetPoller
-            protocol={config.protocol}
             pollIntervalMs={this.state.pollIntervalMs}
             charts={this.state.chartlist}
             windowIntervalMs={this.state.windowIntervalMs}

--- a/src/app/components/Charts/Flamegraph.jsx
+++ b/src/app/components/Charts/Flamegraph.jsx
@@ -24,9 +24,6 @@ import { Button, Form } from 'semantic-ui-react'
 
 const TIMEOUTS = { response: 5000, deadline: 10000 }
 
-// TODO ugh how do we get this cleanly
-import config from '../../config'
-
 function getStatusFromDataset(dataset) {
   // oh for the ?. operator
   return dataset && dataset[0] && dataset[0].data && dataset[0].data[0] && dataset[0].data[0].value || '?'
@@ -65,13 +62,14 @@ class Flamegraph extends React.PureComponent {
     const { chartInfo } = this.props
     const { durationSeconds } = this.state
 
+    const protocol = chartInfo.context.target.protocol
     const hostname = chartInfo.context.target.hostname
     const contextId = chartInfo.context.contextId
     const fgtype = chartInfo.metricNames[0]
 
     try {
       this.setState({ fetchFile: null })
-      await superagent.get(`${config.protocol}://${hostname}/pmapi/${contextId}/_store`)
+      await superagent.get(`${protocol}://${hostname}/pmapi/${contextId}/_store`)
         .timeout(TIMEOUTS)
         .query({ name: fgtype, value: durationSeconds })
     } catch (err) {
@@ -84,6 +82,7 @@ class Flamegraph extends React.PureComponent {
     const { durationSeconds, fetchFile } = this.state
     const { dataset } = this.props
 
+    const protocol = this.props.chartInfo.context.target.protocol
     const hostname = this.props.chartInfo.context.target.hostname
     const status = getStatusFromDataset(dataset)
     const isIdle = ['IDLE', 'ERROR'].includes(status.split(' ')[0])
@@ -110,7 +109,7 @@ class Flamegraph extends React.PureComponent {
         { fetchFile &&
           <div className='doNotDrag'>
             <p>Fetch url: {fetchFile}</p>
-            <a href={`${config.protocol}://${hostname}/${fetchFile}`}
+            <a href={`${protocol}://${hostname}/${fetchFile}`}
               rel='noopener noreferrer' target='_blank' >View / download</a>
           </div> }
 

--- a/src/app/components/ConfigPanel/ContextMenu.jsx
+++ b/src/app/components/ConfigPanel/ContextMenu.jsx
@@ -43,7 +43,7 @@ class ContextMenu extends React.PureComponent {
 
   render () {
     const { contextData, config, initialAddContext, onRemoveContext, onContextSelect, selectedContext } = this.props
-    const { defaultPort, defaultHostspec, disableHostspecInput, disableContainerSelect, useCgroupId } = config
+    const { defaultProtocol, defaultPort, defaultHostspec, disableHostspecInput, disableContainerSelect, useCgroupId } = config
 
     return (
       <Menu vertical pointing attached='top' borderless style={chartSelectorStyle}>
@@ -66,6 +66,7 @@ class ContextMenu extends React.PureComponent {
         <Menu.Item>
           <AddContextModal
             onNewContext={this.handleNewContext}
+            defaultProtocol={defaultProtocol}
             defaultPort={defaultPort}
             defaultHostspec={defaultHostspec}
             disableHostspecInput={disableHostspecInput}

--- a/src/app/components/Pollers/ContextPoller.jsx
+++ b/src/app/components/Pollers/ContextPoller.jsx
@@ -78,7 +78,7 @@ class ContextPoller extends React.Component {
   pollContext = async (existingContext) => {
     const context = { ...existingContext, errText: null }
     try {
-      const pmApi = `${this.props.protocol}://${context.target.hostname}/pmapi`
+      const pmApi = `${context.target.protocol}://${context.target.hostname}/pmapi`
 
       const TIMEOUTS = { response: 5000, deadline: 10000 }
 
@@ -171,10 +171,10 @@ class ContextPoller extends React.Component {
 }
 
 ContextPoller.propTypes = {
-  protocol: PropTypes.string.isRequired,
   targets: PropTypes.arrayOf(
     PropTypes.shape({
       // these should all be passed in as part of the connection setup
+      protocol: PropTypes.string.isRequired,
       hostname: PropTypes.string.isRequired,
       hostspec: PropTypes.string.isRequired,
       containerId: PropTypes.string,

--- a/src/app/components/Pollers/DatasetPoller.jsx
+++ b/src/app/components/Pollers/DatasetPoller.jsx
@@ -69,7 +69,7 @@ class DatasetPoller extends React.Component {
   }
 
   pollMetrics = async () => {
-    const { charts, protocol, windowIntervalMs, onContextDatasetsUpdated } = this.props
+    const { charts, windowIntervalMs, onContextDatasetsUpdated } = this.props
     const { contextDatasets = [] } = this.state
     try {
       if (charts.length == 0) {
@@ -113,7 +113,7 @@ class DatasetPoller extends React.Component {
         // TODO should be able to alarm if we can't find any pmids to match?
 
         let res = await superagent
-          .get(`${protocol}://${q.target.hostname}/pmapi/${q.contextId}/_fetch`)
+          .get(`${q.target.protocol}://${q.target.hostname}/pmapi/${q.contextId}/_fetch`)
           .query({ pmids })
         const oldestS = res.body.timestamp.s - (windowIntervalMs / 1000)
 
@@ -147,7 +147,7 @@ class DatasetPoller extends React.Component {
           const newMapping = {}
           try {
             let res = await superagent
-              .get(`${protocol}://${q.target.hostname}/pmapi/${q.contextId}/_indom`)
+              .get(`${q.target.protocol}://${q.target.hostname}/pmapi/${q.contextId}/_indom`)
               .query({ name })
             res.body.instances.forEach(({ instance, name }) => newMapping[instance] = name)
           } catch (err) {
@@ -186,7 +186,6 @@ DatasetPoller.propTypes = {
   ),
   contextData: PropTypes.array.isRequired,
   onContextDatasetsUpdated: PropTypes.func.isRequired,
-  protocol: PropTypes.string.isRequired,
 }
 
 export default DatasetPoller

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -18,7 +18,6 @@
 
 export default {
   version: '[AIV]{version}[/AIV]', // version number, auto loaded by webpack from package.json
-  protocol: 'http', // PMWEBD protocol (http or https)
 
   dataWindows: [
     { text: '2 min', valueSeconds: 2*60 },
@@ -39,6 +38,7 @@ export default {
   enableBcc: true, // Enable BCC widgets (requires BCC PMDA)
   enableFlamegraphs: true, // Enable Flamegraph widgets (requires custom PMDA)
 
+  defaultProtocol: 'http', // PMWEBD protocol
   defaultPort: 7402, // PMWEBD port
   defaultHostspec: 'localhost', // Default PMCD hostspec
   disableHostspecInput: true, // Disable hostspec input


### PR DESCRIPTION
Adds support for the protocol that's used to communicate with the PCP Web API to be specified against each context.  

The user is given a drop-down when they go to add a new connection:
![image](https://user-images.githubusercontent.com/1682204/54870263-2c996c80-4d9c-11e9-8ab8-422a9fa218ae.png)
