### PR TITLE
feat: specify router basename, externalize config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "jest": {
     "moduleNameMapper": {
       "\\.(css|less|sass|scss)$": "<rootDir>/test/__mocks__/styleMock.js",
-      "\\.(gif|ttf|eot|svg)$": "<rootDir>/test/__mocks__/fileMock.js"
+      "\\.(gif|ttf|eot|svg)$": "<rootDir>/test/__mocks__/fileMock.js",
+      "^config$": "<rootDir>/src/config.js"
     },
     "transform": {
       "^.+\\.jsx$": "babel-jest",

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -34,7 +34,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 import { render } from 'react-dom'
 
-import config from './config'
+import config from 'config'
 
 import Navbar from './components/Navbar/Navbar.jsx'
 import Footer from './components/Footer/Footer.jsx'
@@ -213,7 +213,7 @@ class App extends React.Component {
                 updateChartSettings={this.updateChartSettings}
                 onMoveChart={this.onMoveChart} />
 
-              <Footer version={config.version}/>
+              <Footer version='[AIV]{version}[/AIV]'/>
 
             </Sidebar.Pusher>
 
@@ -252,7 +252,7 @@ class PageRouter extends React.Component {
 
   render () {
     return (
-      <BrowserRouter>
+      <BrowserRouter basename={config.basename}>
         <Switch>
           <Route path="/embed" render={this.AppEmbed}/>
           <Route path="/" render={this.AppNormal}/>

--- a/src/app/charts/index.js
+++ b/src/app/charts/index.js
@@ -19,7 +19,7 @@
 /* eslint-disable */
 
 import { flatten } from '../utils'
-import config from '../config'
+import config from 'config'
 
 // all the remaining components, particularly vector specific angular components
 function requireAll(requireContext) {

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet" />
+    <script type="text/javascript" src="config.js"></script>
 </head>
 <body>
   <div id="app"></div>

--- a/src/app/utils/index.js
+++ b/src/app/utils/index.js
@@ -18,7 +18,7 @@
 
 import superagent from 'superagent'
 import { parse } from 'query-string'
-import config from '../config'
+import config from 'config'
 
 /////////////////////////////////////
 // window.location handling support

--- a/src/app/utils/index.spec.js
+++ b/src/app/utils/index.spec.js
@@ -18,7 +18,7 @@
 
 import * as utils from './'
 import { expect } from 'chai'
-import config from '../config'
+import config from 'config'
 
 describe('getChartsFromLocation', () => {
   describe('with new style search string', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -16,8 +16,8 @@
  *
  */
 
-export default {
-  version: '[AIV]{version}[/AIV]', // version number, auto loaded by webpack from package.json
+const config = {
+  basename: '/',
 
   dataWindows: [
     { text: '2 min', valueSeconds: 2*60 },
@@ -46,4 +46,8 @@ export default {
   useCgroupId: false, // Use container cgroup id instead of container name
 
   // TODO what about container name resolver
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = config;
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -14,6 +14,9 @@ module.exports = {
         filename: 'scripts/bundle.js',
         publicPath: ''
     },
+    externals: {
+        config: 'config'
+    },
     module: {
         rules: [
             {
@@ -85,6 +88,7 @@ module.exports = {
         }),
         // copy static assets
         new CopyWebpackPlugin([
+            { from: 'src/config.js', to: 'config.js' },
             { from: 'src/favicon.ico', to: 'favicon.ico' },
             { from: 'src/assets/images/vector_owl.png', to: 'assets/images/vector_owl.png' }
         ])


### PR DESCRIPTION
The `basename` property of `react-router` is now configurable (required when vector is mounted in a subdirectory instead of a VirtualHost).
Furthermore I've extracted the `config.js` from the webpack bundle into a separate static asset, now configuration changes don't need recompilation of the whole bundle anymore.